### PR TITLE
Use lua-http instead of Prosody net.http

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ The prosody image needs to have the Lua module `http` installed. Install it with
 luarocks install http
 ``` 
 
+A Dockerfile [also exists](https://github.com/matrix-org/docker-jitsi-meet/releases/tag/stable-4857-ems.1) with this built in.
+
 ## License
 
 Apache 2.0

--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ VirtualHost "example.com"
     uvs_base_url = "https://uvs.example.com"
 ```
 
+The prosody image needs to have the Lua module `http` installed. Install it with LuaRocks:
+
+```
+luarocks install http
+``` 
+
 ## License
 
 Apache 2.0


### PR DESCRIPTION
Due to much difficulty working with the Prosody net.http client library, switched to using lua-http. This requires manual installation into the Prosody environment.