### PR TITLE
Support server name passed in Matrix context

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ initialized with the following options:
     },
     "matrix": {
       "token": "DX81zuBbR1Qt7WGnyiIQYdqbDSm2ECnx",
-      "room_id": "!qwertyasdfgh:matrix.org"
+      "room_id": "!qwertyasdfgh:matrix.org",
+      // OPTIONAL
+      "server_name": "matrix.org"
     }
   },
   "aud": "jitsi",
@@ -55,6 +57,7 @@ For generating the token, note the following:
 * `content.user` will be used for the Jitsi Meet session.
 * `matrix.token` is an OpenID token from the Matrix C2S API, see [here](https://matrix.org/docs/spec/client_server/r0.6.1#id154).
 * `matrix.room_id` should be the Matrix room ID we want to check the user is in. When base32 encoded (without padding) it must match the Jitsi room ID.
+* `matrix.server_name` (optional) is the server name the `matrix.token` relates to. If not given, we assume UVS will be configured for a single server.
 * `aud` can be for example "jitsi", should match Prosody token auth issuers/audience if needed.
 * `iss` issuer of the token, must match `app_id` below in Prosody config.
 * `sub` should be the Jitsi Meet domain.

--- a/mod_auth_matrix_user_verification.lua
+++ b/mod_auth_matrix_user_verification.lua
@@ -82,7 +82,7 @@ local function verify_room_membership(matrix)
     if matrix.server_name ~= nil then
         request:set_body(string.format(
             '{"token": "%s", "room_id": "%s", "matrix_server_name": "%s"}',
-            matrix.token, matrix.room_id, matrix.server_name,
+            matrix.token, matrix.room_id, matrix.server_name
         ));
     else
         request:set_body(string.format('{"token": "%s", "room_id": "%s"}', matrix.token, matrix.room_id));

--- a/mod_auth_matrix_user_verification.lua
+++ b/mod_auth_matrix_user_verification.lua
@@ -79,7 +79,14 @@ local function verify_room_membership(matrix)
     local request = http_request.new_from_uri(string.format("%s/verify/user_in_room", uvsUrl));
     request.headers:upsert(":method", "POST");
     request.headers:upsert("content-type", "application/json");
-    request:set_body(string.format('{"token": "%s", "room_id": "%s"}', matrix.token, matrix.room_id));
+    if matrix.server_name ~= nil then
+        request:set_body(string.format(
+            '{"token": "%s", "room_id": "%s", "matrix_server_name": "%s"}',
+            matrix.token, matrix.room_id, matrix.server_name,
+        ));
+    else
+        request:set_body(string.format('{"token": "%s", "room_id": "%s"}', matrix.token, matrix.room_id));
+    end
     local headers, stream = assert(request:go());
     local body = assert(stream:get_body_as_string());
     local status = headers:get(":status");


### PR DESCRIPTION
If the matrix context in the passed in JWT contains a `server_name`, pass it on to UVS in the verify call.

Requires https://github.com/matrix-org/matrix-user-verification-service/pull/5