### PR TITLE
Make mod_auth_matrix_user_verification lookups async

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,16 +135,6 @@ Component "conference.example.com" "muc"
     }
 ```
 
-### Prosody image
-
-The prosody image needs to have the Lua module `http` installed. Install it with LuaRocks:
-
-```
-luarocks install http
-```
-
-A Dockerfile [also exists](https://github.com/matrix-org/docker-jitsi-meet/releases/tag/stable-4857-ems.1) with this built in.
-
 ## License
 
 Apache 2.0


### PR DESCRIPTION
So we don't block prosody.

Removes usage of "http" lua library, using the
prosody built in HTTP library instead.