### PR TITLE
Convert User Verification Service check to a non-blocking HTTP call

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,16 +135,6 @@ Component "conference.example.com" "muc"
     }
 ```
 
-### Prosody image
-
-The prosody image needs to have the Lua module `http` installed. Install it with LuaRocks:
-
-```
-luarocks install http
-```
-
-A Dockerfile [also exists](https://github.com/matrix-org/docker-jitsi-meet/releases/tag/stable-4857-ems.1) with this built in.
-
 ## License
 
 Apache 2.0

--- a/mod_auth_matrix_user_verification.lua
+++ b/mod_auth_matrix_user_verification.lua
@@ -191,10 +191,14 @@ local function process_and_verify_token(session)
         return false, "access-denied", "Jitsi room does not match Matrix room"
     end
 
-    local isMember, isOwner = verify_room_membership(data.context.matrix)
+    local isMember, isOwner = verify_room_membership(data.context.matrix);
 
-    if isMember == false then
+    if isMember ~= true then
         return false, "access-denied", "Token invalid or not in room";
+    end
+
+    if isOwner ~= true then
+        isOwner = false
     end
 
     -- Store the isOwner detail

--- a/mod_auth_matrix_user_verification.lua
+++ b/mod_auth_matrix_user_verification.lua
@@ -13,7 +13,11 @@
 -- limitations under the License.
 --
 -- Based on https://github.com/jitsi/jitsi-meet/blob/b765adca752c5bda95b15791e8421852c8ab7000/resources/prosody-plugins/mod_auth_token.lua
+-- Code referenced for async portion: https://hg.prosody.im/prosody-modules/file/39156d6f7268/mod_auth_http_async/mod_auth_http_async.lua
+-- net.http documentation: https://prosody.im/doc/developers/net/http
+-- util.async documentation: https://prosody.im/doc/developers/util/async
 
+local async = require "util.async";
 local formdecode = require "util.http".formdecode;
 local generate_uuid = require "util.uuid".generate;
 local jid = require "util.jid";
@@ -22,7 +26,7 @@ local new_sasl = require "util.sasl".new;
 local sasl = require "util.sasl";
 local sessions = prosody.full_sessions;
 local basexx = require "basexx";
-local http_request = require "http.request";
+local http = require "net.http";
 local json = require "util.json";
 
 -- Ensure configured
@@ -99,52 +103,69 @@ end
 -- Check room membership from UVS
 -- Returns boolean(isMember), boolean(isOwner)
 local function verify_room_membership(matrix)
-    local request = http_request.new_from_uri(string.format("%s/verify/user_in_room", uvsUrl));
-    request.headers:upsert(":method", "POST");
-    request.headers:upsert("content-type", "application/json");
+    -- Set necessary HTTP headers for the request
+    local options = {};
+    options.headers = {};
+    options.headers["Content-Type"] = "application/json";
     if uvsAuthToken ~= nil then
         module:log("debug", "Setting authentication header with Bearer token");
-        request.headers:upsert(
-            "authorization",
-            string.format("Bearer %s", uvsAuthToken)
-        )
+        options.headers["Authorization"] = string.format("Bearer %s", uvsAuthToken)
     end
-    module:log("info", "Found matrix %s %s", matrix.room_id, matrix.server_name);
+
+    -- Set the body of the request with details provided by the client
+    module:log("info", "Found room ID: %s, server_name: %s", matrix.room_id, matrix.server_name);
     if matrix.server_name ~= nil then
-        request:set_body(string.format(
-            '{"token": "%s", "room_id": "%s", "matrix_server_name": "%s"}',
-            matrix.token, matrix.room_id, matrix.server_name
-        ));
+        options.body = json.encode({ token = matrix.token, room_id = matrix.room_id, matrix_server_name = matrix.server_name });
     else
-        request:set_body(string.format('{"token": "%s", "room_id": "%s"}', matrix.token, matrix.room_id));
+        options.body = json.encode({ token = matrix.token, room_id = matrix.room_id });
     end
-    local headers, stream = assert(request:go());
-    local body = assert(stream:get_body_as_string());
-    local status = headers:get(":status");
-    if status == "200" then
-        local data = json.decode(body);
-        if data.results then
-            if data.results.user == true and data.results.room_membership == true then
-                if uvsSyncPowerLevels and data.power_levels ~= nil then
-                    -- If the user power in the room is at least "state_detault", we mark them as owner
-                    if data.power_levels.user >= data.power_levels.room.state_default then
-                        return true, true;
-                    end
-                end
-                return true, false;
-            else
-                if data.results.user == true and data.results.room_membership == false then
-                    module:log("info", "REQUEST_COMPLETE reason:not_in_room")
-                else
-                    module:log("info", "REQUEST_COMPLETE reason:invalid_token")
-                end
-            end
-        else
-            module:log("info", "REQUEST_COMPLETE reason:invalid_response")
+
+    -- We want to make this HTTP call in an asynchronous manner
+    -- wait and done allow us to pause execution of the function while we wait for a long-running operation,
+    -- such as contacting the User Verification Service, to complete.
+    -- We pause the function with wait, then call done() when the request is complete to unpause where we left off
+    local wait, done = async.waiter();
+    local data;
+
+    -- The request will automatically have a method of POST if a body is included
+    local function cb(response_body, response_code, request, response)
+	module:log("debug", "Response code: %d", response_code);
+	module:log("debug", "Response body: %s", response_body);
+
+        if response_code == 200 then
+            -- Deserialise the body
+            data = json.decode(response_body);
         end
-    else
-        module:log("info", "REQUEST_COMPLETE reason:exception")
+
+        done();
     end
+
+    -- Make the request and pause execution of this function until done is called above
+    http.request(string.format("%s/verify/user_in_room", uvsUrl), options, cb);
+    wait();
+
+    if data == nil or not data.results then
+        module:log("info", "REQUEST_COMPLETE reason:invalid_response")
+	return false, false;
+    end
+
+    if data.results.user == true and data.results.room_membership == true then
+        if uvsSyncPowerLevels and data.power_levels ~= nil then
+            -- If the user power in the room is at least "state_default", we mark them as owner
+            if data.power_levels.user >= data.power_levels.room.state_default then
+                return true, true;
+            end
+        end
+	-- The user is in the room, but they're not considered a moderator
+        return true, false;
+    else
+        if data.results.user == true and data.results.room_membership == false then
+            module:log("info", "REQUEST_COMPLETE reason:not_in_room")
+        else
+            module:log("info", "REQUEST_COMPLETE reason:invalid_token")
+        end
+    end
+
     return false, false;
 end
 

--- a/mod_auth_matrix_user_verification.lua
+++ b/mod_auth_matrix_user_verification.lua
@@ -127,10 +127,9 @@ local function verify_room_membership(matrix)
     local wait, done = async.waiter();
     local data;
 
-    -- The request will automatically have a method of POST if a body is included
     local function cb(response_body, response_code, request, response)
-	module:log("debug", "Response code: %d", response_code);
-	module:log("debug", "Response body: %s", response_body);
+        module:log("debug", "Response code: %d", response_code);
+        module:log("debug", "Response body: %s", response_body);
 
         if response_code == 200 then
             -- Deserialise the body
@@ -141,12 +140,13 @@ local function verify_room_membership(matrix)
     end
 
     -- Make the request and pause execution of this function until done is called above
+    -- Note the request will automatically have a method of POST if a body is included
     http.request(string.format("%s/verify/user_in_room", uvsUrl), options, cb);
     wait();
 
     if data == nil or not data.results then
         module:log("info", "REQUEST_COMPLETE reason:invalid_response")
-	return false, false;
+        return false, false;
     end
 
     if data.results.user == true and data.results.room_membership == true then
@@ -156,7 +156,8 @@ local function verify_room_membership(matrix)
                 return true, true;
             end
         end
-	-- The user is in the room, but they're not considered a moderator
+
+        -- The user is in the room, but they're not considered a moderator
         return true, false;
     else
         if data.results.user == true and data.results.room_membership == false then


### PR DESCRIPTION
Fixes #10

This PR reworks the bit where we make a call out to the User Verification Service in order to check a user's provided credentials. Instead of a blocking HTTP call, we now do the call async, allowing Prosody to continue serving requests while we wait for the response.

#9 was an initial attempt to do the same and was quite close! But it had a couple bugs in it, one being the very non-obvious fact that `options.body` needs to be the JSON string and not be set directly to a table.

Tested with success on my own Jitsi Auth setup. One thing I noticed while doing so is that if `verify_room_membership` happened to return `nil` for it's first return argument, the user would be allowed into the Jitsi room. This was due to us only checking whether the return value of `isMember` was `false`, rather than checking it was not `true`. The second commit tackles that problem as a defensive measure.

Signed-off-by: Andrew Morgan <andrewm@element.io>